### PR TITLE
Facebook has changed time format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.php
+config.inc.php
 nbproject/

--- a/lib/facebook-php-sdk/src/base_facebook.php
+++ b/lib/facebook-php-sdk/src/base_facebook.php
@@ -732,7 +732,7 @@ abstract class BaseFacebook
       $this->getUrl('graph', $path),
       $params
     ), true);
-
+    
     // results are returned, errors are thrown
     if (is_array($result) && isset($result['error'])) {
       $this->throwAPIException($result);
@@ -761,7 +761,7 @@ abstract class BaseFacebook
         $params[$key] = json_encode($value);
       }
     }
-
+    
     return $this->makeRequest($url, $params);
   }
 
@@ -799,8 +799,22 @@ abstract class BaseFacebook
       $opts[CURLOPT_HTTPHEADER] = array('Expect:');
     }
 
+    echo '<pre>';
+    var_dump($result);
+    unset($opts["10015"]["page_id"]);
+    unset($opts["10015"]["privacy_type"]);
+    unset($opts["10015"]["location"]);
+    unset($opts["10015"]["method"]);
+    unset($opts["10015"]["access_token"]);
+    var_dump($opts);
+    
+    echo '</pre>';
+    //die();
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);
+
+    var_dump($result);
+    die();
 
     if (curl_errno($ch) == 60) { // CURLE_SSL_CACERT
       self::errorLog('Invalid or no certificate authority found, '.
@@ -822,6 +836,7 @@ abstract class BaseFacebook
       throw $e;
     }
     curl_close($ch);
+    
     return $result;
   }
 

--- a/lib/facebook-php-sdk/src/base_facebook.php
+++ b/lib/facebook-php-sdk/src/base_facebook.php
@@ -776,22 +776,6 @@ abstract class BaseFacebook
    *
    * @return string The response text
    */
-/*
-  protected function makeRequest($url, $params, $ch=null) {
-      if (!$ch) {
-          $ch = curl_init();
-      }
-
-      $opts = self::$CURL_OPTS;
-      curl_setopt($ch, CURLOPT_URL ,$url);
-      curl_setopt($ch, CURLOPT_POST, 1);
-      curl_setopt($ch, CURLOPT_POSTFIELDS,
-                  http_build_query(array()));
-      var_dump($params);
-      die();
-
-  }
-*/
 
   protected function makeRequest($url, $params, $ch=null) {
     if (!$ch) {
@@ -816,12 +800,11 @@ abstract class BaseFacebook
       $opts[CURLOPT_HTTPHEADER] = array('Expect:');
     }
 
-    var_dump($opts[CURLOPT_URL]);
-
-    if (isset($opts["10015"]["start_time"]))
-        $opts["10015"]["start_time"] = $iso8601 = date('c', $opts["10015"]["start_time"]);
-    if (isset($opts["10015"]["end_time"]))
-        $opts["10015"]["end_time"] = $iso8601 = date('c', $opts["10015"]["end_time"]);
+    /* Convert unix timestamp to ISO 8601 */
+    if (isset($opts[CURLOPT_POSTFIELDS]["start_time"]))
+        $opts[CURLOPT_POSTFIELDS]["start_time"] = date('c', $opts[CURLOPT_POSTFIELDS]["start_time"]);
+    if (isset($opts[CURLOPT_POSTFIELDS]["end_time"]))
+        $opts[CURLOPT_POSTFIELDS]["end_time"] = date('c', $opts[CURLOPT_POSTFIELDS]["end_time"]);
     
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);

--- a/lib/facebook-php-sdk/src/base_facebook.php
+++ b/lib/facebook-php-sdk/src/base_facebook.php
@@ -776,6 +776,23 @@ abstract class BaseFacebook
    *
    * @return string The response text
    */
+/*
+  protected function makeRequest($url, $params, $ch=null) {
+      if (!$ch) {
+          $ch = curl_init();
+      }
+
+      $opts = self::$CURL_OPTS;
+      curl_setopt($ch, CURLOPT_URL ,$url);
+      curl_setopt($ch, CURLOPT_POST, 1);
+      curl_setopt($ch, CURLOPT_POSTFIELDS,
+                  http_build_query(array()));
+      var_dump($params);
+      die();
+
+  }
+*/
+
   protected function makeRequest($url, $params, $ch=null) {
     if (!$ch) {
       $ch = curl_init();
@@ -799,22 +816,15 @@ abstract class BaseFacebook
       $opts[CURLOPT_HTTPHEADER] = array('Expect:');
     }
 
-    echo '<pre>';
-    var_dump($result);
-    unset($opts["10015"]["page_id"]);
-    unset($opts["10015"]["privacy_type"]);
-    unset($opts["10015"]["location"]);
-    unset($opts["10015"]["method"]);
-    unset($opts["10015"]["access_token"]);
-    var_dump($opts);
+    var_dump($opts[CURLOPT_URL]);
+
+    if (isset($opts["10015"]["start_time"]))
+        $opts["10015"]["start_time"] = $iso8601 = date('c', $opts["10015"]["start_time"]);
+    if (isset($opts["10015"]["end_time"]))
+        $opts["10015"]["end_time"] = $iso8601 = date('c', $opts["10015"]["end_time"]);
     
-    echo '</pre>';
-    //die();
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);
-
-    var_dump($result);
-    die();
 
     if (curl_errno($ch) == 60) { // CURLE_SSL_CACERT
       self::errorLog('Invalid or no certificate authority found, '.

--- a/lib/facebook-php-sdk/src/base_facebook.php
+++ b/lib/facebook-php-sdk/src/base_facebook.php
@@ -193,6 +193,11 @@ abstract class BaseFacebook
   protected $accessToken = null;
 
   /**
+   * If true the event creation will not be posted on the wall.
+   */
+  protected $silentPosting;
+
+  /**
    * Indicates if the CURL based @ syntax for file uploads is enabled.
    *
    * @var boolean
@@ -210,6 +215,7 @@ abstract class BaseFacebook
    * @param array $config The application configuration
    */
   public function __construct($config) {
+    $this->setSilentPosting($config['silentEvent']);
     $this->setAppId($config['appId']);
     $this->setApiSecret($config['secret']);
     if (isset($config['fileUpload'])) {
@@ -231,6 +237,11 @@ abstract class BaseFacebook
   public function setAppId($appId) {
     $this->appId = $appId;
     return $this;
+  }
+
+  public function setSilentPosting($silent) {
+      $this->silentPosting = $silent;
+      return $this;
   }
 
   /**
@@ -803,8 +814,11 @@ abstract class BaseFacebook
     /* Convert unix timestamp to ISO 8601 */
     if (isset($opts[CURLOPT_POSTFIELDS]["start_time"]))
         $opts[CURLOPT_POSTFIELDS]["start_time"] = date('c', $opts[CURLOPT_POSTFIELDS]["start_time"]);
+    
     if (isset($opts[CURLOPT_POSTFIELDS]["end_time"]))
         $opts[CURLOPT_POSTFIELDS]["end_time"] = date('c', $opts[CURLOPT_POSTFIELDS]["end_time"]);
+
+    $opts[CURLOPT_POSTFIELDS]["no_feed_story"] = 1;
     
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);


### PR DESCRIPTION
Facebook has changed the time format that should be given when creating an event (start_time and end_time).

I have made a quick hack that converts from unix timestamp to ISO 8601.

See: https://developers.facebook.com/docs/reference/api/page/#events
